### PR TITLE
Fix write_lambda expressions

### DIFF
--- a/Esphome code
+++ b/Esphome code
@@ -304,9 +304,7 @@ number:
     lambda: "return  x * 0.1; "
     write_lambda: |-
       ESP_LOGD("main","Modbus Number incoming value = %f",x);
-      uint16_t c_capacity = x * 10 ;
-      payload.push_back(c_capacity);
-      return x * 1.0 ;
+      return x * 10.0 ;
     ## multiply is ignored because lamdba is used
     multiply: 1
     
@@ -322,10 +320,7 @@ number:
     step: 1
     lambda: "return  x * 0.1; "
     write_lambda: |-
-      ESP_LOGD("main","Modbus Number incoming value = %f",x);
-      uint16_t c_capacity = x * 10 ;
-      payload.push_back(c_capacity);
-      return x * 1.0 ;
+      return x * 10.0 ;
     ## multiply is ignored because lamdba is used
     multiply: 1
 


### PR DESCRIPTION
Your  code isn't able to write back values to the unit.
The documentation of mod-bus write_lambda isn't correct.
After a bit of browsing the Esphome  modbus code. I found the correct  format, for this purpose.
